### PR TITLE
Fix wall layer splitting if-block braces

### DIFF
--- a/Scripts/WallLayerSplitter.cs
+++ b/Scripts/WallLayerSplitter.cs
@@ -226,7 +226,7 @@ namespace WallRvt.Scripts
                         topConstraintId, topOffset, unconnectedHeight, wall.Flipped, isStructural, locationLine);
 
                     if (newWall.WallType.Id != layerType.Id)
-                    
+                    {
                         CopyInstanceParameters(wall, newWall);
                         createdWalls.Add(newWall.Id);
                         layerWallInfos.Add(new LayerWallInfo(newWall, layer, index, layerOffsetFromReference));


### PR DESCRIPTION
## Summary
- wrap the wall creation bookkeeping in braces so the operations run only when the wall type check passes

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cd32464b28832396c288ae8c0fa00f