### PR TITLE
Call rehosting before deleting original wall

### DIFF
--- a/Scripts/WallLayerSplitter.cs
+++ b/Scripts/WallLayerSplitter.cs
@@ -204,8 +204,6 @@ namespace WallRvt.Scripts
             double referenceOffset = CalculateReferenceOffset(structure, layers, wallLocationLine, exteriorFaceOffset);
             IList<LayerWallInfo> layerWallInfos = new List<LayerWallInfo>();
 
-            const double offsetTolerance = 1e-9;
-
             for (int index = 0; index < layers.Count; index++)
             {
                 CompoundStructureLayer layer = layers[index];
@@ -225,15 +223,9 @@ namespace WallRvt.Scripts
                     Wall newWall = CreateWallFromLayer(document, offsetCurve, layerType, baseLevelId, baseOffset,
                         topConstraintId, topOffset, unconnectedHeight, wall.Flipped, isStructural, locationLine);
 
-                    if (newWall.WallType.Id != layerType.Id)
-                    
-                        CopyInstanceParameters(wall, newWall);
-                        createdWalls.Add(newWall.Id);
-                        layerWallInfos.Add(new LayerWallInfo(newWall, layer, index, layerOffsetFromReference));
-                    }
-
                     CopyInstanceParameters(wall, newWall);
                     createdWalls.Add(newWall.Id);
+                    layerWallInfos.Add(new LayerWallInfo(newWall, layer, index, layerOffsetFromReference));
                 }
                 catch (Exception ex)
                 {
@@ -241,6 +233,12 @@ namespace WallRvt.Scripts
                         $"Не удалось создать стену для слоя {index + 1}: {ex.Message}");
                 }
             }
+
+            IList<ElementId> rehostedInstances;
+            IList<ElementId> unmatchedInstances;
+
+            RehostFamilyInstances(document, wall, layerWallInfos, baseCurve, wallOrientation,
+                out rehostedInstances, out unmatchedInstances);
 
             if (!createdWalls.Any())
             {


### PR DESCRIPTION
## Summary
- ensure layer wall information is collected for every created layer wall
- invoke RehostFamilyInstances before deleting the original wall and include its results in the split outcome

## Testing
- dotnet build WallLayerSplitter.csproj -c Release *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68cd32482bcc8323a2e9706f261618d8