### PR TITLE
Update fire rating parameter enum for Revit 2024

### DIFF
--- a/Scripts/WallLayerSplitter.cs
+++ b/Scripts/WallLayerSplitter.cs
@@ -575,7 +575,11 @@ namespace WallRvt.Scripts
             BuiltInParameter.WALL_USER_HEIGHT_PARAM,
             BuiltInParameter.WALL_STRUCTURAL_SIGNIFICANT,
             BuiltInParameter.WALL_ATTR_ROOM_BOUNDING,
+#if REVIT_2024_OR_GREATER
+            BuiltInParameter.WALL_FIRE_RATING_PARAM
+#else
             BuiltInParameter.WALL_ATTR_FIRE_RATING
+#endif
         };
 
         private static void CopyInstanceParameters(Wall source, Wall target)


### PR DESCRIPTION
## Summary
- switch the fire rating parameter in the default copy list to use the Revit 2024+ identifier when available via conditional compilation

## Testing
- not run (environment missing dotnet/Autodesk Revit assemblies)


------
https://chatgpt.com/codex/tasks/task_e_68cd34af4b7483238344c39f2fa81171