### PR TITLE
Fix InvalidOperationException alias to avoid ambiguity

### DIFF
--- a/Scripts/WallLayerSplitter.cs
+++ b/Scripts/WallLayerSplitter.cs
@@ -8,6 +8,7 @@ using Autodesk.Revit.DB;
 using Autodesk.Revit.Exceptions;
 using Autodesk.Revit.UI;
 using Autodesk.Revit.UI.Selection;
+using InvalidOperationException = System.InvalidOperationException;
 using RevitOperationCanceledException = Autodesk.Revit.Exceptions.OperationCanceledException;
 
 namespace WallRvt.Scripts


### PR DESCRIPTION
## Summary
- add an alias to ensure `InvalidOperationException` resolves to the System type

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cd34afaa888323b6b282289d788020