### PR TITLE
Replace deprecated hosted element retrieval API

### DIFF
--- a/Scripts/WallLayerSplitter.cs
+++ b/Scripts/WallLayerSplitter.cs
@@ -654,7 +654,7 @@ namespace WallRvt.Scripts
                 return;
             }
 
-            ICollection<ElementId> hostedElementIds = HostObjectUtils.GetHostedElements(document, originalWall.Id);
+            ICollection<ElementId> hostedElementIds = HostObjectUtils.GetDirectlyHostedElements(document, originalWall.Id);
             if (hostedElementIds == null || hostedElementIds.Count == 0)
             {
                 return;


### PR DESCRIPTION
## Summary
- replace HostObjectUtils.GetHostedElements with the new GetDirectlyHostedElements call to match the current Revit API

## Testing
- not run (dotnet CLI is not available in the container)

------
https://chatgpt.com/codex/tasks/task_e_68cd34b110d88323932783477808e950