### PR TITLE
Add legacy fallback for retrieving hosted elements

### DIFF
--- a/Scripts/WallLayerSplitter.cs
+++ b/Scripts/WallLayerSplitter.cs
@@ -659,7 +659,11 @@ namespace WallRvt.Scripts
                 return;
             }
 
+#if REVIT_2024_OR_GREATER
             ICollection<ElementId> hostedElementIds = HostObjectUtils.GetDirectlyHostedElements(document, originalWall.Id);
+#else
+            ICollection<ElementId> hostedElementIds = GetDirectlyHostedElementsLegacy(document, originalWall);
+#endif
             if (hostedElementIds == null || hostedElementIds.Count == 0)
             {
                 return;
@@ -689,6 +693,76 @@ namespace WallRvt.Scripts
                 }
             }
         }
+
+#if !REVIT_2024_OR_GREATER
+        private static ICollection<ElementId> GetDirectlyHostedElementsLegacy(Document document, Wall hostWall)
+        {
+            if (document == null || hostWall == null)
+            {
+                return Array.Empty<ElementId>();
+            }
+
+            ICollection<ElementId> allHostedElementIds = HostObjectUtils.GetAllHostedElements(document, hostWall.Id);
+            if (allHostedElementIds == null || allHostedElementIds.Count == 0)
+            {
+                return Array.Empty<ElementId>();
+            }
+
+            IList<ElementId> directlyHosted = new List<ElementId>();
+            foreach (ElementId hostedId in allHostedElementIds)
+            {
+                Element hostedElement = document.GetElement(hostedId);
+                if (hostedElement == null)
+                {
+                    continue;
+                }
+
+                if (IsElementDirectlyHostedOnWall(hostedElement, hostWall))
+                {
+                    directlyHosted.Add(hostedId);
+                }
+            }
+
+            return directlyHosted;
+        }
+
+        private static bool IsElementDirectlyHostedOnWall(Element hostedElement, Wall hostWall)
+        {
+            if (hostedElement == null || hostWall == null)
+            {
+                return false;
+            }
+
+            if (hostedElement is FamilyInstance familyInstance)
+            {
+                Element familyHost = familyInstance.Host;
+                if (familyHost != null && familyHost.Id == hostWall.Id)
+                {
+                    return true;
+                }
+
+                Reference hostFace = familyInstance.HostFace;
+                if (hostFace != null && hostFace.ElementId == hostWall.Id)
+                {
+                    return true;
+                }
+
+                return false;
+            }
+
+            Parameter hostParameter = hostedElement.get_Parameter(BuiltInParameter.HOST_ID_PARAM);
+            if (hostParameter != null && hostParameter.StorageType == StorageType.ElementId)
+            {
+                ElementId hostId = hostParameter.AsElementId();
+                if (hostId != null && hostId == hostWall.Id)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+#endif
 
         private LayerWallInfo SelectLayerForInstance(FamilyInstance familyInstance, Curve baseCurve, XYZ wallOrientation,
             IList<LayerWallInfo> layerWalls)


### PR DESCRIPTION
## Summary
- guard the call to HostObjectUtils.GetDirectlyHostedElements behind a Revit version symbol
- provide a legacy helper that filters GetAllHostedElements to mimic direct hosting semantics

## Testing
- dotnet build *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68cd368fb3f08323908a1241aac968d0