### PR TITLE
Уточнить проверку статуса владения стеной

### DIFF
--- a/Scripts/WallLayerSplitter.cs
+++ b/Scripts/WallLayerSplitter.cs
@@ -938,7 +938,8 @@ namespace WallRvt.Scripts
             if (document.IsWorkshared)
             {
                 CheckoutStatus checkoutStatus = WorksharingUtils.GetCheckoutStatus(document, wall.Id);
-                if (checkoutStatus != CheckoutStatus.OwnedByMe && checkoutStatus != CheckoutStatus.NotOwned)
+                if (checkoutStatus == CheckoutStatus.OwnedByOtherUser ||
+                    checkoutStatus == CheckoutStatus.OwnedByOtherUserInCurrentSession)
                 {
                     detectedReasons.Add("стена занята другим пользователем или находится в недоступном рабочем наборе");
                 }


### PR DESCRIPTION
## Summary
- скорректировал проверку статуса владения стеной на конкретные значения, которые возвращает Revit 2022
- сохранил сообщение об ошибке для случая, когда элемент занят другим пользователем

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cd3eb5409083239e7444b4d881e6f7