### PR TITLE
Use workset table when validating wall deletion

### DIFF
--- a/Scripts/WallLayerSplitter.cs
+++ b/Scripts/WallLayerSplitter.cs
@@ -946,7 +946,8 @@ namespace WallRvt.Scripts
                 WorksetId worksetId = wall.WorksetId;
                 if (worksetId != WorksetId.InvalidWorksetId)
                 {
-                    Workset workset = WorksetTable.GetWorkset(document, worksetId);
+                    WorksetTable worksetTable = document.GetWorksetTable();
+                    Workset workset = worksetTable.GetWorkset(worksetId);
                     if (workset != null && !workset.IsEditable)
                     {
                         detectedReasons.Add($"рабочий набор \"{workset.Name}\" не передан вам для редактирования");


### PR DESCRIPTION
## Summary
- request the document workset table before fetching a workset
- continue checking that non-editable worksets block wall deletion

## Testing
- not run (Revit assemblies are not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68cd3eb592488323bb190fe91225b747