### PR TITLE
Handle checkout status compatibility with older Revit API

### DIFF
--- a/Scripts/WallLayerSplitter.cs
+++ b/Scripts/WallLayerSplitter.cs
@@ -938,8 +938,7 @@ namespace WallRvt.Scripts
             if (document.IsWorkshared)
             {
                 CheckoutStatus checkoutStatus = WorksharingUtils.GetCheckoutStatus(document, wall.Id);
-                if (checkoutStatus == CheckoutStatus.OwnedByOtherUser ||
-                    checkoutStatus == CheckoutStatus.OwnedByOtherUserInCurrentSession)
+                if (IsOwnedByAnotherUser(checkoutStatus))
                 {
                     detectedReasons.Add("стена занята другим пользователем или находится в недоступном рабочем наборе");
                 }
@@ -979,6 +978,17 @@ namespace WallRvt.Scripts
 
             reason = string.Join("; ", detectedReasons) + ".";
             return false;
+        }
+
+        private static bool IsOwnedByAnotherUser(CheckoutStatus checkoutStatus)
+        {
+            if (checkoutStatus == CheckoutStatus.OwnedByOtherUser)
+            {
+                return true;
+            }
+
+            string statusName = checkoutStatus.ToString();
+            return string.Equals(statusName, "OwnedByOtherUserInCurrentSession", StringComparison.OrdinalIgnoreCase);
         }
 
         private void ReportSkipReason(ElementId wallId, string reason)


### PR DESCRIPTION
## Summary
- replace direct use of the missing `CheckoutStatus.OwnedByOtherUserInCurrentSession` constant with a helper that checks the name at runtime so the code builds on older API versions

## Testing
- Not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cd41cbc77c83238c32e05666785f99