### PR TITLE
Use element overload of AreElementsJoined

### DIFF
--- a/Scripts/WallLayerSplitter.cs
+++ b/Scripts/WallLayerSplitter.cs
@@ -1299,7 +1299,7 @@ namespace WallRvt.Scripts
                 bool elementsJoined = true;
                 try
                 {
-                    elementsJoined = JoinGeometryUtils.AreElementsJoined(document, first.Id, second.Id);
+                    elementsJoined = JoinGeometryUtils.AreElementsJoined(document, first, second);
                 }
                 catch (Autodesk.Revit.Exceptions.ArgumentException)
                 {
@@ -1319,7 +1319,7 @@ namespace WallRvt.Scripts
 
                 try
                 {
-                    return !JoinGeometryUtils.AreElementsJoined(document, first.Id, second.Id);
+                    return !JoinGeometryUtils.AreElementsJoined(document, first, second);
                 }
                 catch (Autodesk.Revit.Exceptions.ArgumentException)
                 {


### PR DESCRIPTION
## Summary
- use the element-based overload of `JoinGeometryUtils.AreElementsJoined` in `TryUnjoinGeometry` to avoid passing element ids directly

## Testing
- not run (dotnet CLI is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cd550dc4c88323a0baeda31f5cb2ca