### PR TITLE
Skip original wall when checking dependencies

### DIFF
--- a/Scripts/WallLayerSplitter.cs
+++ b/Scripts/WallLayerSplitter.cs
@@ -1164,6 +1164,11 @@ namespace WallRvt.Scripts
                             continue;
                         }
 
+                        if (dependentId == wall.Id)
+                        {
+                            continue;
+                        }
+
                         int dependentInteger = dependentId.IntegerValue;
 
                         if (detachedFamilyIds != null && detachedFamilyIds.Contains(dependentInteger))


### PR DESCRIPTION
## Summary
- skip the original wall when scanning dependent elements so it does not block deletion

## Testing
- dotnet build *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd59aff4b48323aab64fd9407090e4