### PR TITLE
Remove unsupported future annotations import

### DIFF
--- a/pyrevit/extension/WallLayerSplitter.extension/lib/logger.py
+++ b/pyrevit/extension/WallLayerSplitter.extension/lib/logger.py
@@ -5,8 +5,6 @@
 функций, которые можно вызывать из команд расширения.
 """
 
-from __future__ import annotations
-
 from pyrevit import script
 
 


### PR DESCRIPTION
## Summary
- remove the __future__ annotations import from the logger helper so IronPython can execute the module

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d0f95fe3dc8323b3d22bfdf430c4ca