### PR TITLE
Store original wall ElementId before deletion

### DIFF
--- a/pyrevit/extension/WallLayerSplitter.extension/WallLayerSplitter.tab/Wall Tools.panel/SplitLayers.pushbutton/script.py
+++ b/pyrevit/extension/WallLayerSplitter.extension/WallLayerSplitter.tab/Wall Tools.panel/SplitLayers.pushbutton/script.py
@@ -250,7 +250,8 @@ class WallLayerSplitterCommand(object):
             LOGGER.debug("SplitWall: передана пустая стена.")
             return None
 
-        wall_id = wall.Id.IntegerValue
+        original_wall_id = wall.Id
+        wall_id = original_wall_id.IntegerValue
         self.log_diagnostic("Стена {0}: сбор исходных данных.".format(wall_id))
 
         structure = wall.WallType.GetCompoundStructure() if wall.WallType else None
@@ -280,7 +281,7 @@ class WallLayerSplitterCommand(object):
                 else:
                     delete_reason = "не удалось временно отвязать семейства: {}".format(failed_list)
             self.restore_family_instances_to_host(detached_instances, wall)
-            self.report_skip_reason(wall.Id, "невозможно удалить исходную стену: {}".format(delete_reason))
+            self.report_skip_reason(original_wall_id, "невозможно удалить исходную стену: {}".format(delete_reason))
             self.log_diagnostic(
                 "Стена {0}: невозможно удалить исходную стену ({1}).".format(wall_id, delete_reason or "неизвестная причина")
             )
@@ -349,7 +350,7 @@ class WallLayerSplitterCommand(object):
 
         try:
             self.log_diagnostic("Стена {0}: удаление исходной стены.".format(wall_id))
-            self.doc.Delete(wall.Id)
+            self.doc.Delete(original_wall_id)
         except InvalidOperationException as ex:
             self.restore_family_instances_to_host(detached_instances, wall)
             raise InvalidOperationException(
@@ -374,7 +375,7 @@ class WallLayerSplitterCommand(object):
         )
 
         result = WallSplitResult(
-            wall.Id,
+            original_wall_id,
             created_walls,
             rehosted_instances,
             unmatched_instances,


### PR DESCRIPTION
## Summary
- capture each wall's ElementId before splitting to preserve the identifier after deletion
- reuse the stored ElementId for skip reporting and split results once the original wall has been removed

## Testing
- not run (Revit is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d104e12b2c83239ea423b5f7cf0bf5