### PR TITLE
Fix transaction group name for wall layer splitter

### DIFF
--- a/pyrevit/extension/WallLayerSplitter.extension/WallLayerSplitter.tab/Wall Tools.panel/SplitLayers.pushbutton/script.py
+++ b/pyrevit/extension/WallLayerSplitter.extension/WallLayerSplitter.tab/Wall Tools.panel/SplitLayers.pushbutton/script.py
@@ -277,7 +277,7 @@ class WallLayerSplitterCommand(object):
 
         split_results = []
 
-        tgroup = TransactionGroup(self.doc, "Разделение слоёв стен")
+        tgroup = TransactionGroup(self.doc, "Разделение слоев стен")
         try:
             tgroup.Start()
             LOGGER.debug("TransactionGroup начата.")
@@ -1078,7 +1078,7 @@ class WallLayerSplitterCommand(object):
         return detached_elements
 
     def show_summary(self, results, skipped_messages):
-        builder = ["Результат разделения слоёв стен:"]
+        builder = ["Результат разделения слоев стен:"]
         total_created = 0
         total_rehosted = 0
         total_unmatched = 0


### PR DESCRIPTION
## Summary
- replace the transaction group title with a version that avoids the `ё` character so Revit no longer throws an ArgumentException when starting the command
- adjust the corresponding summary caption to use the same normalized wording

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d134623fdc8323ad0674cfccf96343