### PR TITLE
Handle missing ActiveDesignOptionId on older Revit versions

### DIFF
--- a/pyrevit/extension/WallLayerSplitter.extension/WallLayerSplitter.tab/Wall Tools.panel/SplitLayers.pushbutton/script.py
+++ b/pyrevit/extension/WallLayerSplitter.extension/WallLayerSplitter.tab/Wall Tools.panel/SplitLayers.pushbutton/script.py
@@ -1041,7 +1041,11 @@ class WallLayerSplitterCommand(object):
         design_option_id = get_design_option_id(wall)
         try:
             active_option = self.doc.ActiveDesignOptionId
-        except InvalidOperationException:
+        except (AttributeError, InvalidOperationException):
+            # Свойство ActiveDesignOptionId появилось в API Revit сравнительно недавно,
+            # поэтому на старых версиях приложения его может не быть. В этом случае,
+            # а также если Revit запрещает читать активную дизайн-опцию, считаем,
+            # что активной опции нет (ElementId.InvalidElementId).
             active_option = ElementId.InvalidElementId
         if design_option_id != ElementId.InvalidElementId and design_option_id != active_option:
             option_description = build_design_option_description(self.doc, design_option_id)


### PR DESCRIPTION
## Summary
- guard access to Document.ActiveDesignOptionId when the property is missing
- treat missing design option API or access issues as no active design option

## Testing
- not run (Revit environment not available)


------
https://chatgpt.com/codex/tasks/task_e_68d1404f623883238047759bdcfe753b