### PR TITLE
Add fallback for missing wall phase parameter

### DIFF
--- a/pyrevit/extension/WallLayerSplitter.extension/lib/revit_stub.py
+++ b/pyrevit/extension/WallLayerSplitter.extension/lib/revit_stub.py
@@ -11,7 +11,6 @@
 from __future__ import annotations
 
 import enum
-from typing import Any
 
 __all__ = [
     "ArgumentException",


### PR DESCRIPTION
## Summary
- add fallback names for wall phase built-in parameters so the splitter can work on API versions that lack the wall-specific constants
- log when a fallback parameter is used and tidy stub imports

## Testing
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68d1470a7b588323aec06b4e6288f99a